### PR TITLE
Fix nextjs pages artifact build

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/configure-pages@v4
         
       - name: Build with Next.js
-        run: npm run build
+        run: npm run build && npm run export
         
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "export": "next export",
     "start": "next start",
     "type-check": "tsc --noEmit"
   },


### PR DESCRIPTION
## Summary
- ensure Next.js build exports to `out` before deploying
- add missing `export` script

## Testing
- `npm run type-check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6882ebe4c398832fb607dee9d32cf36e