### PR TITLE
Add Early Access section

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -210,6 +210,83 @@ const LandingConversao: React.FC = () => {
 
 
         <DynamicTestimonials />
+        {/* Early Access Section */}
+        <section className="py-20 bg-gray-50">
+          <div className="max-w-4xl mx-auto px-4">
+            <div className="text-center mb-16">
+              <h2 className="text-4xl md:text-5xl font-bold mb-8 leading-tight">
+                A Techway tá só começando.<br />
+                Mas quem entra agora,<br />
+                <span className="text-blue-600">entra pra fazer história.</span>
+              </h2>
+              <p className="text-lg md:text-xl text-gray-600 leading-relaxed max-w-3xl mx-auto">
+                Estamos lançando os primeiros módulos dos nossos funcionários digitais — e queremos fazer isso junto com
+                empresas que também são mão na massa, que resolvem, testam, opinam e crescem.
+              </p>
+              <p className="text-lg md:text-xl text-gray-600 leading-relaxed max-w-3xl mx-auto mt-6">
+                Por isso, criamos o programa <strong className="text-blue-600">Early Access</strong>: uma fase de acesso
+                antecipado com vantagens exclusivas pra quem topar construir o futuro com a gente.
+              </p>
+            </div>
+
+            <h3 className="text-2xl md:text-3xl font-bold mb-12 text-center text-gray-900">Quem entra agora, leva:</h3>
+            <div className="space-y-16">
+              <div className="border-l-4 border-blue-600 pl-8">
+                <h4 className="text-xl font-bold mb-2 text-gray-900">Acesso antecipado</h4>
+                <p className="text-lg text-gray-600 leading-relaxed">
+                  Experimente em primeira mão os novos módulos da Techway — funcionalidades que ainda nem foram lançadas
+                  oficialmente.
+                </p>
+              </div>
+
+              <div className="border-l-4 border-blue-600 pl-8">
+                <h4 className="text-xl font-bold mb-2 text-gray-900">Condições especiais de contratação</h4>
+                <p className="text-lg text-gray-600 leading-relaxed">
+                  Vagas limitadas: só as 10 primeiras empresas vão garantir condições exclusivas. Os detalhes? Só descobre
+                  quem entra.
+                </p>
+              </div>
+
+              <div className="border-l-4 border-blue-600 pl-8">
+                <h4 className="text-xl font-bold mb-2 text-gray-900">Canal direto com o time da Techway</h4>
+                <p className="text-lg text-gray-600 leading-relaxed">
+                  Tenha acesso direto ao nosso time e receba uma consultoria de negócio na prática, enquanto cocriamos
+                  juntos o futuro da ferramenta.
+                </p>
+              </div>
+
+              <div className="border-l-4 border-blue-600 pl-8">
+                <h4 className="text-xl font-bold mb-2 text-gray-900">Produto moldado à sua realidade</h4>
+                <p className="text-lg text-gray-600 leading-relaxed">
+                  Ao participar do Early Access, sua empresa ajuda a definir as soluções — e sai com um produto
+                  praticamente feito sob medida.
+                </p>
+              </div>
+
+              <div className="border-l-4 border-blue-600 pl-8">
+                <h4 className="text-xl font-bold mb-2 text-gray-900">Reconhecimento como empresa parceira fundadora</h4>
+                <p className="text-lg text-gray-600 leading-relaxed">
+                  Sua marca pode ganhar visibilidade como referência, aparecendo nas nossas comunicações e ajudando a
+                  inspirar outros negócios.
+                </p>
+              </div>
+            </div>
+
+            <div className="text-center mt-12">
+              <p className="text-lg md:text-xl text-gray-600 mb-8 leading-relaxed">
+                Se a sua empresa gosta de testar, ajustar e transformar com tecnologia de verdade —{' '}
+                <strong className="text-blue-600">bora conversar.</strong>
+              </p>
+              <a
+                href="#contato"
+                className="bg-blue-600 hover:bg-blue-700 text-white font-semibold py-4 px-8 rounded transition duration-300 inline-flex items-center text-lg"
+              >
+                Quero fazer parte do Early Access
+                <ArrowRight className="ml-2 w-5 h-5" />
+              </a>
+            </div>
+          </div>
+        </section>
 
         {/* CTA Final Section */}
         <section id="contato" className="py-20 bg-blue-600 text-white">


### PR DESCRIPTION
## Summary
- add new Early Access section to home page
- restyle early access bullets to match feature list

## Testing
- `npm run type-check` *(fails: JSX element implicitly has type 'any')*

------
https://chatgpt.com/codex/tasks/task_e_68858a60c094832f818c3e067870e1d1