### PR TITLE
Add WhatsApp contact links

### DIFF
--- a/components/ContactChat.tsx
+++ b/components/ContactChat.tsx
@@ -108,7 +108,7 @@ const ContactChat: React.FC = () => {
   const handleWhatsApp = () => {
     const message = `Olá! Meu nome é ${formData.name}. Gostaria de saber mais sobre como a TECHWAY pode me ajudar com ${formData.need}.`;
     const encodedMessage = encodeURIComponent(message);
-    window.open(`https://wa.me/5511999999999?text=${encodedMessage}`, '_blank');
+    window.open(`https://wa.me/5521991673541?text=${encodedMessage}`, '_blank');
   };
 
   const handleSubmit = () => {

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -32,7 +32,7 @@ const Footer: React.FC<FooterProps> = ({ className = '' }) => {
             <p>
               <span className="font-bold">WhatsApp:{" "}</span>
               <a
-                href="https://wa.me/5521991673541"
+                href="https://wa.me/5521991673541?text=Ol%C3%A1!%20Vi%20o%20site%20de%20voc%C3%AAs%20e%20quero%20falar%20com%20o%20time." 
                 className="hover:text-blue-400 transition-colors duration-300"
                 target="_blank"
                 rel="noopener noreferrer"

--- a/components/Testimonials.tsx
+++ b/components/Testimonials.tsx
@@ -161,7 +161,12 @@ export default function Testimonials() {
           </div>
         </div>
         <div className="text-center mt-12">
-          <a href="#contato" className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-6 rounded-lg text-lg transition duration-300">
+          <a
+            href="https://wa.me/5521991673541?text=Ol%C3%A1!%20Vi%20o%20site%20de%20voc%C3%AAs%20e%20quero%20resultados%20como%20esses."
+            target="_blank"
+            rel="noopener noreferrer"
+            className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-6 rounded-lg text-lg transition duration-300"
+          >
             Quero resultados como esses
           </a>
         </div>

--- a/components/WhatsAppButton.tsx
+++ b/components/WhatsAppButton.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { MessageCircle } from 'lucide-react'
+
+interface WhatsAppButtonProps {
+  message?: string
+}
+
+const PHONE_NUMBER = '5521991673541'
+
+const WhatsAppButton: React.FC<WhatsAppButtonProps> = ({ message = 'Olá! Vi o site de vocês e quero meu novo funcionário digital' }) => {
+  const encodedMessage = encodeURIComponent(message)
+  const href = `https://wa.me/${PHONE_NUMBER}?text=${encodedMessage}`
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="fixed bottom-4 right-4 bg-green-500 hover:bg-green-600 text-white p-4 rounded-full shadow-lg z-50"
+      aria-label="Conversar no WhatsApp"
+    >
+      <MessageCircle className="w-6 h-6" />
+    </a>
+  )
+}
+
+export default WhatsAppButton

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,12 @@
 import type { AppProps } from 'next/app'
 import '../styles/globals.css'
+import WhatsAppButton from '../components/WhatsAppButton'
 
 export default function App({ Component, pageProps }: AppProps): JSX.Element {
-  return <Component {...pageProps} />
+  return (
+    <>
+      <Component {...pageProps} />
+      <WhatsAppButton />
+    </>
+  )
 }

--- a/pages/din_page.tsx
+++ b/pages/din_page.tsx
@@ -9,6 +9,9 @@ import Testimonials from '../components/Testimonials'
 import { landingPages } from '../data/landingPages'
 import type { PageData } from '../types/PageData'
 
+const waLink = (message: string) =>
+  `https://wa.me/5521991673541?text=${encodeURIComponent(message)}`
+
 const iconComponents = {
   CheckCircle,
   Award,
@@ -79,7 +82,12 @@ export default function DynamicLandingPage() {
             <p className="text-xl mb-8 text-center font-bold">
               {pageData.hero.heroSubtitle}
             </p>
-            <a href="#contato" className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-6 rounded-lg text-lg transition duration-300">
+            <a
+              href={waLink(`Olá! Vi o site de vocês e ${pageData.hero.heroCTA.toLowerCase()}.`)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-6 rounded-lg text-lg transition duration-300"
+            >
               {pageData.hero.heroCTA}
             </a>
           </div>
@@ -125,8 +133,10 @@ export default function DynamicLandingPage() {
                   {pageData.solution.solutionText_1}
                 </p>
                 <div className="text-center">
-                  <a 
-                    href={pageData.solution.solutionctalink_1}
+                  <a
+                    href={waLink(`Olá! Vi o site de vocês e ${pageData.solution.solutionctatext_1.toLowerCase()}.`)}
+                    target="_blank"
+                    rel="noopener noreferrer"
                     className="text-blue-400 hover:text-blue-300 font-semibold inline-block relative group"
                   >
                     {pageData.solution.solutionctatext_1}
@@ -143,8 +153,10 @@ export default function DynamicLandingPage() {
                   {pageData.solution.solutionText_2}
                 </p>
                 <div className="text-center">
-                  <a 
-                    href={pageData.solution.solutionctalink_2}
+                  <a
+                    href={waLink(`Olá! Vi o site de vocês e ${pageData.solution.solutionctatext_2.toLowerCase()}.`)}
+                    target="_blank"
+                    rel="noopener noreferrer"
                     className="text-blue-400 hover:text-blue-300 font-semibold inline-block relative group"
                   >
                     {pageData.solution.solutionctatext_2}
@@ -161,8 +173,10 @@ export default function DynamicLandingPage() {
                   {pageData.solution.solutionText_3}
                 </p>
                 <div className="text-center">
-                  <a 
-                    href={pageData.solution.solutionctalink_3}
+                  <a
+                    href={waLink(`Olá! Vi o site de vocês e ${pageData.solution.solutionctatext_3.toLowerCase()}.`)}
+                    target="_blank"
+                    rel="noopener noreferrer"
                     className="text-blue-400 hover:text-blue-300 font-semibold inline-block relative group"
                   >
                     {pageData.solution.solutionctatext_3}
@@ -228,7 +242,9 @@ export default function DynamicLandingPage() {
           <div className="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
             <h2 className="text-3xl md:text-4xl font-bold mb-8 text-white">{pageData.cta.ctaText}</h2>
             <a
-              href={pageData.cta.ctaLink}
+              href={waLink(`Olá! Vi o site de vocês e ${pageData.cta.ctaButton.toLowerCase()}.`)}
+              target="_blank"
+              rel="noopener noreferrer"
               className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-8 rounded-lg text-lg transition duration-300 inline-block"
             >
               {pageData.cta.ctaButton}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -72,7 +72,9 @@ const LandingConversao: React.FC = () => {
               </span>
             </div>
             <a
-              href="#solucoes"
+              href="https://wa.me/5521991673541?text=Ol%C3%A1!%20Vi%20o%20site%20de%20voc%C3%AAs%20e%20quero%20saber%20mais."
+              target="_blank"
+              rel="noopener noreferrer"
               className="bg-blue-600 hover:bg-blue-700 text-white font-semibold py-4 px-8 rounded transition duration-300 inline-flex items-center text-lg"
             >
               Quero saber mais
@@ -278,7 +280,9 @@ const LandingConversao: React.FC = () => {
                 <strong className="text-blue-600">bora conversar.</strong>
               </p>
               <a
-                href="#contato"
+                href="https://wa.me/5521991673541?text=Ol%C3%A1!%20Vi%20o%20site%20de%20voc%C3%AAs%20e%20quero%20fazer%20parte%20do%20Early%20Access."
+                target="_blank"
+                rel="noopener noreferrer"
                 className="bg-blue-600 hover:bg-blue-700 text-white font-semibold py-4 px-8 rounded transition duration-300 inline-flex items-center text-lg"
               >
                 Quero fazer parte do Early Access
@@ -310,7 +314,7 @@ const LandingConversao: React.FC = () => {
             </div>
 
             <a
-              href="https://wa.me/5521991673541"
+              href="https://wa.me/5521991673541?text=Ol%C3%A1!%20Vi%20o%20site%20de%20voc%C3%AAs%20e%20quero%20meu%20novo%20funcion%C3%A1rio%20digital."
               target="_blank"
               rel="noopener noreferrer"
               className="bg-white hover:bg-gray-100 text-gray-900 font-semibold py-6 px-12 rounded transition duration-300 inline-flex items-center text-xl"

--- a/pages/index_old.tsx
+++ b/pages/index_old.tsx
@@ -59,7 +59,12 @@ const Home: React.FC = () => {
               A TECHWAY <span className="text-blue-400">simplifica sua operação</span> com soluções tecnológicas sob medida. <br />
               <span className="text-blue-400 font-bold">Mais produtividade.</span> <span className="font-bold">Menos dor de cabeça.</span>
             </p>
-            <a href="#contato" className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-6 rounded-lg text-lg transition duration-300">
+            <a
+              href="https://wa.me/5521991673541?text=Ol%C3%A1!%20Vi%20o%20site%20de%20voc%C3%AAs%20e%20quero%20otimizar%20meus%20processos."
+              target="_blank"
+              rel="noopener noreferrer"
+              className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-6 rounded-lg text-lg transition duration-300"
+            >
               Otimize Já os Seus Processos
             </a>
           </div>
@@ -130,7 +135,12 @@ const Home: React.FC = () => {
                   Elimine processos repetitivos e concentre-se no que realmente importa. Nossas automações se ajustarão perfeitamente às suas operações, economizando tempo e recursos.
                 </p>
                 <div className="text-center">
-                  <a href="#contato" className="text-blue-400 hover:text-blue-300 font-semibold inline-block relative group">
+                  <a
+                    href="https://wa.me/5521991673541?text=Ol%C3%A1!%20Vi%20o%20site%20de%20voc%C3%AAs%20e%20quero%20transformar%20minha%20opera%C3%A7%C3%A3o."
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-400 hover:text-blue-300 font-semibold inline-block relative group"
+                  >
                     &gt; Descubra como transformar sua operação &lt;
                     <span className="absolute left-0 right-0 bottom-0 h-0.5 bg-blue-400 transform scale-x-0 group-hover:scale-x-100 transition-transform duration-300"></span>
                   </a>
@@ -145,7 +155,12 @@ const Home: React.FC = () => {
                   Quem tem controle dos seus dados, está a um passo do sucesso. Elaboramos Dashboards sob medida para o seu negócio, que transformam números em decisões estratégicas.
                 </p>
                 <div className="text-center">
-                  <a href="#contato" className="text-blue-400 hover:text-blue-300 font-semibold inline-block relative group">
+                  <a
+                    href="https://wa.me/5521991673541?text=Ol%C3%A1!%20Vi%20o%20site%20de%20voc%C3%AAs%20e%20quero%20ver%20meus%20dados%20trabalhando%20por%20mim."
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-400 hover:text-blue-300 font-semibold inline-block relative group"
+                  >
                     &gt; Veja seus dados trabalhando por você &lt;
                     <span className="absolute left-0 right-0 bottom-0 h-0.5 bg-blue-400 transform scale-x-0 group-hover:scale-x-100 transition-transform duration-300"></span>
                   </a>
@@ -160,7 +175,12 @@ const Home: React.FC = () => {
                   Criamos soluções tecnológicas sob medida, adaptadas à realidade e desafios do seu negócio. Nossas ferramentas certamente farão a diferença onde sua empresa mais precisa.
                 </p>
                 <div className="text-center">
-                  <a href="#contato" className="text-blue-400 hover:text-blue-300 font-semibold inline-block relative group">
+                  <a
+                    href="https://wa.me/5521991673541?text=Ol%C3%A1!%20Vi%20o%20site%20de%20voc%C3%AAs%20e%20quero%20descobrir%20o%20impacto%20das%20nossas%20ferramentas."
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-400 hover:text-blue-300 font-semibold inline-block relative group"
+                  >
                     &gt; Descubra o impacto das nossas ferramentas &lt;
                     <span className="absolute left-0 right-0 bottom-0 h-0.5 bg-blue-400 transform scale-x-0 group-hover:scale-x-100 transition-transform duration-300"></span>
                   </a>

--- a/pages/privacidade.tsx
+++ b/pages/privacidade.tsx
@@ -110,7 +110,12 @@ const PoliticaDePrivacidade: React.FC = (): JSX.Element => {
             <p className="mb-8 text-xl">
               Entre em contato conosco para esclarecimentos adicionais.
             </p>
-            <a href="/#contato" className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-6 rounded-lg text-lg transition duration-300">
+            <a
+              href="https://wa.me/5521991673541?text=Ol%C3%A1!%20Vi%20o%20site%20de%20voc%C3%AAs%20e%20tenho%20d%C3%BAvidas%20sobre%20a%20pol%C3%ADtica%20de%20privacidade."
+              target="_blank"
+              rel="noopener noreferrer"
+              className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-6 rounded-lg text-lg transition duration-300"
+            >
               Fale Conosco
             </a>
           </div>

--- a/pages/termos.tsx
+++ b/pages/termos.tsx
@@ -110,7 +110,12 @@ const TermosDeUso: React.FC = (): JSX.Element => {
             <p className="mb-8 text-xl">
               Entre em contato conosco para esclarecimentos adicionais.
             </p>
-            <a href="/#contato" className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-6 rounded-lg text-lg transition duration-300">
+            <a
+              href="https://wa.me/5521991673541?text=Ol%C3%A1!%20Vi%20o%20site%20de%20voc%C3%AAs%20e%20tenho%20d%C3%BAvidas%20sobre%20os%20termos%20de%20uso."
+              target="_blank"
+              rel="noopener noreferrer"
+              className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-6 rounded-lg text-lg transition duration-300"
+            >
               Fale Conosco
             </a>
           </div>


### PR DESCRIPTION
## Summary
- create `WhatsAppButton` floating component
- attach floating WhatsApp button globally
- update call‑to‑action links to open WhatsApp with predefined messages
- adjust contact numbers in chat component

## Testing
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6886d7e9fb44832fbbe34fe35f108607