### PR TITLE
Fix blog CTA link causing build error

### DIFF
--- a/data/blogPosts.json
+++ b/data/blogPosts.json
@@ -92,11 +92,11 @@
         "image": "/liberdade_empresario.webp"
       }
     ],
-    "conclusion": "Se você sente que sua empresa depende 100% de você pra tudo, talvez esteja na hora de mudar. A Techway pode te ajudar a dar o primeiro passo, com soluções de atendimento automático, follow-up inteligente e muito mais. Tudo funcionando direto no WhatsApp da sua empresa, com o seu jeito. Bora destravar seu negócio?",
-    "cta": {
-      "text": "Conheça seu primeiro funcionário digital",
-      "link": "/"
-    }
+    "conclusion": "Se você sente que sua empresa depende 100% de você pra tudo, talvez esteja na hora de mudar. A Techway pode te ajudar a dar o primeiro passo, com soluções de atendimento automático, follow-up inteligente e muito mais. Tudo funcionando direto no WhatsApp da sua empresa, com o seu jeito. Bora destravar seu negócio?"
+  },
+  "cta": {
+    "text": "Conheça seu primeiro funcionário digital",
+    "link": "/"
   },
   "tags": ["atendimento", "automação", "rotina de empreendedores", "funcionário digital"]
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "techway-site",
       "version": "0.1.0",
       "dependencies": {
-        "lucide-react": "^0.32.0",
+        "lucide-react": "^0.526.0",
         "next": "14.0.3",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
@@ -1022,13 +1022,12 @@
       "license": "ISC"
     },
     "node_modules/lucide-react": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.32.0.tgz",
-      "integrity": "sha512-ljuWGBbIV/md1NPkLSw9i9W1RhbquWKHe8Jtp2rSUfiJF6xr7QlatQkQXTWSKb+x7Lx1Whw2wAP3SGjruF2eXg==",
+      "version": "0.526.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.526.0.tgz",
+      "integrity": "sha512-uGWG/2RKuDLeQHCodn5cmJ9Zij80EstOdcBP+j//B2sr78w7woiEL4aMu6CRlRkyOyJ8sZry8QLhQTmZjynLdA==",
       "license": "ISC",
       "peerDependencies": {
-        "prop-types": "^15.7.2",
-        "react": "^16.5.1 || ^17.0.0"
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/merge2": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "lucide-react": "^0.32.0",
+    "lucide-react": "^0.526.0",
     "next": "14.0.3",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",


### PR DESCRIPTION
## Summary
- update one blog post's CTA field to match other posts
- bump lucide-react to v0.526.0 to resolve React 18 peer dependency

## Testing
- `npm install --legacy-peer-deps`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6886ee930990832f8568e547199330f4